### PR TITLE
Fix validation loader

### DIFF
--- a/systems/bakedsdf.py
+++ b/systems/bakedsdf.py
@@ -34,7 +34,7 @@ class BakedSDFSystem(BaseSystem):
     
     def preprocess_data(self, batch, stage):
         if 'index' in batch: # validation / testing
-            index = batch['index']
+            index = batch['index'].to(self.dataset.all_images.device)
         else:
             if self.config.model.batch_image_sampling:
                 index = torch.randint(0, len(self.dataset.all_images), size=(self.train_num_rays,), device=self.dataset.all_images.device)

--- a/systems/neus.py
+++ b/systems/neus.py
@@ -33,7 +33,7 @@ class NeuSSystem(BaseSystem):
     
     def preprocess_data(self, batch, stage):
         if 'index' in batch: # validation / testing
-            index = batch['index']
+            index = batch['index'].to(self.dataset.all_images.device)
         else:
             if self.config.model.batch_image_sampling:
                 index = torch.randint(0, len(self.dataset.all_images), size=(self.train_num_rays,), device=self.dataset.all_images.device)


### PR DESCRIPTION
Training crashes during validation loop as `dataset.all_images` are on cpu, while index is on cuda.